### PR TITLE
PRO-80 : Add observer on config file & Fix fetching without access token bug & Changing commands name & Access to private repository on Gitlab

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,16 +18,20 @@
   "contributes": {
     "commands": [
       {
-        "command": "extension.openDropdown",
-        "title": "Show related documentations",
+        "command": "docx.openDropdown",
+        "title": "Docx: Show related documentations",
         "icon": {
           "light": "images/book-light.svg",
           "dark": "images/book-light.svg"
         }
       },
       {
-        "command": "Docx Github Add Token",
-        "title": "Docx Github - Add token"
+        "command": "docx.addGithubToken",
+        "title": "Docx: Github - Add token"
+      },
+      {
+        "command": "docx.addGitlabToken",
+        "title": "Docx: Gitlab - Add token"
       },
       {
         "command": "Docx Gitlab Add Token",
@@ -37,7 +41,7 @@
     "menus": {
       "editor/title": [
         {
-          "command": "extension.openDropdown",
+          "command": "docx.openDropdown",
           "group": "navigation"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -34,8 +34,12 @@
         "title": "Docx: Gitlab - Add token"
       },
       {
-        "command": "Docx Gitlab Add Token",
-        "title": "Docx Gitlab - Add token"
+        "command": "docx.deleteGithubToken",
+        "title": "Docx: Github - Delete token"
+      },
+      {
+        "command": "docx.deleteGitlabToken",
+        "title": "Docx: Gitlab - Delete token"
       }
     ],
     "menus": {

--- a/src/api/repository.strategy.ts
+++ b/src/api/repository.strategy.ts
@@ -31,18 +31,22 @@ export class RepositoryProviderStrategy implements ProviderStrategy {
     return knownRepositories.some((domain) => docLocation.includes(domain))
   }
 
-  getProviderConfig(docLocation: string, tokens: Token[]): ProviderConfig {
+  getProviderConfig(docLocation: string, tokens?: Token[]): ProviderConfig {
     const domain = knownRepositories.find((domain) => docLocation.includes(domain))
     if (!domain) {
       ErrorManager.outputError(`Unrecognized repository domain in URL: ${docLocation}`)
       throw new Error(`Unrecognized repository domain in URL: ${docLocation}`)
     }
     const repositoryName = this.extractRepositoryName(domain)
-    const token = tokens.find((token) => token.provider === repositoryName)!.key
+
+    let token
+    if (tokens && tokens.length > 0) {
+      token = tokens.find((token) => token.provider === repositoryName)?.key
+    }
     return {
       type: repositoryName,
       repositories: [docLocation],
-      token: token,
+      token,
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,10 +14,6 @@ export async function activate(context: vscode.ExtensionContext) {
   const credentialManager = new CredentialManager(context.secrets)
   let tokens = await credentialManager.getTokens()
 
-  credentialManager.onTokenChange(async () => {
-    tokens = await credentialManager.getTokens()
-  })
-
   ErrorManager.initialize()
   SchemaManager.initialize(
     '/.docx.json',
@@ -45,6 +41,11 @@ export async function activate(context: vscode.ExtensionContext) {
     `${workspaceFolder}/${configFilename}`
   )
   configFileObserver.onDidChange(async () => {
+    ;[jsonConfig, documentations] = await refreshDocumentations()
+  })
+
+  credentialManager.onTokenChange(async () => {
+    tokens = await credentialManager.getTokens()
     ;[jsonConfig, documentations] = await refreshDocumentations()
   })
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,8 +93,17 @@ export async function activate(context: vscode.ExtensionContext) {
     async () => await credentialManager.openTokenInputBox('gitlab')
   )
 
+  const commandGithubDeleteToken = vscode.commands.registerCommand('docx.deleteGithubToken', () =>
+    credentialManager.deleteTokenAndNotify('github')
+  )
+  const commandGitlabDeleteToken = vscode.commands.registerCommand('docx.deleteGitlabToken', () =>
+    credentialManager.deleteTokenAndNotify('gitlab')
+  )
+
   context.subscriptions.push(commandGithubAddToken)
   context.subscriptions.push(commandGitlabAddToken)
+  context.subscriptions.push(commandGithubDeleteToken)
+  context.subscriptions.push(commandGitlabDeleteToken)
   context.subscriptions.push(disposable)
 }
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ;[jsonConfig, documentations] = await refreshDocumentations()
   })
 
-  const disposable = vscode.commands.registerCommand('extension.openDropdown', async () => {
+  const disposable = vscode.commands.registerCommand('docx.openDropdown', async () => {
     const currentUserPath = WorkspaceManager.getCurrentUserPath()
     if (!currentUserPath) return
 
@@ -84,12 +84,12 @@ export async function activate(context: vscode.ExtensionContext) {
   })
 
   const commandGithubAddToken = vscode.commands.registerCommand(
-    'Docx Github Add Token',
+    'docx.addGithubToken',
     async () => await credentialManager.openTokenInputBox('github')
   )
 
   const commandGitlabAddToken = vscode.commands.registerCommand(
-    'Docx Gitlab Add Token',
+    'docx.addGitlabToken',
     async () => await credentialManager.openTokenInputBox('gitlab')
   )
 

--- a/src/utils/credentials.utils.ts
+++ b/src/utils/credentials.utils.ts
@@ -13,19 +13,24 @@ export class CredentialManager {
     this.providers = ['github', 'gitlab']
   }
 
-  private saveToken = async (token: Token) => {
-    await this.secretStorage.store(token.provider, token.key)
-  }
-
   public openTokenInputBox = async (provider: Token['provider']) => {
     const inputValue = await vscode.window.showInputBox({
-      placeHolder: `${provider.charAt(0).toUpperCase()}${provider.slice(1)} Personnal Access Token`,
+      placeHolder: `${provider.charAt(0).toUpperCase() + provider.slice(1)} Personnal Access Token`,
     })
     if (inputValue) {
       this.saveToken({
         provider,
         key: inputValue,
       })
+      vscode.window.showInformationMessage(
+        `Docx ${
+          provider.charAt(0).toUpperCase() + provider.slice(1)
+        } Personnal Access Token has been saved successfully.
+        `,
+        'Close'
+      )
+    }
+  }
 
   public deleteTokenAndNotify = async (provider: Token['provider']) => {
     this.deleteToken(provider)
@@ -52,7 +57,7 @@ export class CredentialManager {
     }
   }
 
-  public getTokens = async (): Promise<Token[]> => {
+  public getTokens = async (): Promise<Token[] | undefined> => {
     const tokens: Token[] = []
 
     for (const provider of this.providers) {
@@ -60,7 +65,7 @@ export class CredentialManager {
       if (token) tokens.push(token)
     }
 
-    return tokens
+    return tokens.length ? tokens : undefined
   }
 
   private deleteToken = (provider: Token['provider']) => {

--- a/src/utils/credentials.utils.ts
+++ b/src/utils/credentials.utils.ts
@@ -26,11 +26,20 @@ export class CredentialManager {
         provider,
         key: inputValue,
       })
-      vscode.window.showInformationMessage(
-        `Docx ${provider} Personnal Access Token has been saved successfully.`,
-        'Close'
-      )
-    }
+
+  public deleteTokenAndNotify = async (provider: Token['provider']) => {
+    this.deleteToken(provider)
+    vscode.window.showInformationMessage(
+      `Docx
+      ${
+        provider.charAt(0).toUpperCase() + provider.slice(1)
+      } Personnal Access Token has been deleted successfully.`,
+      'Close'
+    )
+  }
+
+  private saveToken = async (token: Token) => {
+    await this.secretStorage.store(token.provider, token.key)
   }
 
   private getToken = async (provider: Token['provider']): Promise<Token | undefined> => {
@@ -54,7 +63,7 @@ export class CredentialManager {
     return tokens
   }
 
-  public deleteToken = (provider: Token['provider']) => {
+  private deleteToken = (provider: Token['provider']) => {
     this.secretStorage.delete(provider)
   }
 


### PR DESCRIPTION
- When config file is saved, it refresh the docs
- When the token is saved, it refresh the docs
- Fix fetching when there's no access token saved
- Change command name to more conventional name
- Plug the token to Gitlab provider to access to private repository on Gitlab